### PR TITLE
Ensure DPI aware for correct screen resolution detection

### DIFF
--- a/game/CMakeLists.txt
+++ b/game/CMakeLists.txt
@@ -475,3 +475,8 @@ if (PLATFORM_MAC AND PSYDOOM_INCLUDE_VULKAN_RENDERER)
         COMMAND cp "${PROJECT_SOURCE_DIR}/Game/Resources/macOS/MoltenVK_icd.json" "$<TARGET_FILE_DIR:${GAME_TGT_NAME}>/../Resources/vulkan/icd.d"
     )
 endif()
+
+# Windows: make game DPI-aware so it correctly detects screen resolution
+if (PLATFORM_WINDOWS)
+    set_property(TARGET ${GAME_TGT_NAME} PROPERTY VS_DPI_AWARE "PerMonitor")
+endif()


### PR DESCRIPTION
I realized the game wouldn't run in 3840x2160 on my screen, only 2560x1440.

That's because I have 150% DPI as Windows suggests, else things are way too small.

This fixes it, it works by adding a manifest to the binary that specifies application is High-DPI aware.

Now I can go back and enjoy the game in pixel perfect mode!