### PR TITLE
Another linux build fix

### DIFF
--- a/baselib/IniUtils.h
+++ b/baselib/IniUtils.h
@@ -2,6 +2,7 @@
 
 #include "Macros.h"
 
+#include <cstdint>
 #include <functional>
 #include <string>
 

--- a/game/PsyDoom/Audio/AudioVoice.cpp
+++ b/game/PsyDoom/Audio/AudioVoice.cpp
@@ -6,6 +6,7 @@
 #include "Spu.h"
 
 #include <algorithm>
+#include <cmath>
 
 BEGIN_NAMESPACE(AudioVoiceUtils)
 

--- a/game/PsyDoom/SaveAndLoad.h
+++ b/game/PsyDoom/SaveAndLoad.h
@@ -2,6 +2,7 @@
 
 #include "Macros.h"
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
More linux build errors.

Fixed errors by including cstdint:
```
In file included from baselib/IniUtils.cpp:22:
error: 'uint32_t' does not name a type
   83 |     inline uint32_t getAsUint() const THROWS {
      |            ^~~~~~~~
baselib/IniUtils.h:7:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    6 | #include <string>
  +++ |+#include <cstdint>
    7 |
baselib/IniUtils.h:87:12: error: 'uint32_t' does not name a type
   87 |     inline uint32_t tryGetAsUint(const uint32_t defaultValue) const noexcept {
      |            ^~~~~~~~
baselib/IniUtils.h:87:12: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?

In file included from game/PsyDoom/SaveAndLoad.cpp:5: game/PsyDoom/SaveAndLoad.h:30:6: warning: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword
   30 | enum class SaveFileSlot : uint8_t {
      | ~~~~ ^~~~~
      |      -----
game/PsyDoom/SaveAndLoad.h:30:25: error: found ‘:’ in nested-name-specifier, expected ‘::’
   30 | enum class SaveFileSlot : uint8_t {
      |                         ^
      |                         ::
game/PsyDoom/SaveAndLoad.h:30:12: error: ‘SaveFileSlot’ has not been declared
   30 | enum class SaveFileSlot : uint8_t {
      |            ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.h:30:35: error: expected unqualified-id before ‘{’ token
   30 | enum class SaveFileSlot : uint8_t {
      |                                   ^
game/PsyDoom/SaveAndLoad.h:43:8: error: ‘SaveFileSlot’ does not name a type
   43 | extern SaveFileSlot                             gCurSaveSlot;
      |        ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.h:48:39: error: ‘SaveFileSlot’ does not name a type
   48 | const char* getSaveFileBaseName(const SaveFileSlot slot) noexcept;
      |                                       ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.h:49:35: error: ‘SaveFileSlot’ does not name a type
   49 | std::string getSaveFilePath(const SaveFileSlot slot) noexcept;
      |                                   ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:39:1: error: ‘SaveFileSlot’ does not name a type; did you mean ‘SaveFileHdr’?
   39 | SaveFileSlot gCurSaveSlot = SaveFileSlot::NONE;
      | ^~~~~~~~~~~~
      | SaveFileHdr
game/PsyDoom/SaveAndLoad.cpp:674:39: error: ‘SaveFileSlot’ does not name a type; did you mean ‘SaveFileHdr’?
  674 | const char* getSaveFileBaseName(const SaveFileSlot slot) noexcept {
      |                                       ^~~~~~~~~~~~
      |                                       SaveFileHdr
game/PsyDoom/SaveAndLoad.cpp: In function ‘const char* SaveAndLoad::getSaveFileBaseName(int)’:
game/PsyDoom/SaveAndLoad.cpp:676:14: error: ‘SaveFileSlot’ has not been declared
  676 |         case SaveFileSlot::SAVE1:       return "Save1.sav";
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:677:14: error: ‘SaveFileSlot’ has not been declared
  677 |         case SaveFileSlot::SAVE2:       return "Save2.sav";
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:678:14: error: ‘SaveFileSlot’ has not been declared
  678 |         case SaveFileSlot::SAVE3:       return "Save3.sav";
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:679:14: error: ‘SaveFileSlot’ has not been declared
  679 |         case SaveFileSlot::QUICKSAVE:   return "Quick.sav";
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:680:14: error: ‘SaveFileSlot’ has not been declared
  680 |         case SaveFileSlot::AUTOSAVE:    return "Auto.sav";
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp:681:14: error: ‘SaveFileSlot’ has not been declared
  681 |         case SaveFileSlot::NONE:        break;
      |              ^~~~~~~~~~~~
game/PsyDoom/SaveAndLoad.cpp: At global scope:
game/PsyDoom/SaveAndLoad.cpp:691:35: error: ‘SaveFileSlot’ does not name a type; did you mean ‘SaveFileHdr’?
  691 | std::string getSaveFilePath(const SaveFileSlot slot) noexcept {
      |                                   ^~~~~~~~~~~~
      |                                   SaveFileHdr

```
Fixed by including cmath:
```
game/PsyDoom/Audio/AudioVoice.cpp: In function 'Spu::SpuCallbackOutput AudioVoiceUtils::stepVoiceImpl(AudioVoice&, const SoundCache&)': game/PsyDoom/Audio/AudioVoice.cpp:56:29: error: 'fmod' is not a member of 'std'
   56 |         newSamplePos = std::fmod(newSamplePos, numSamples);
      |                             ^~~~
```