### PR TITLE
Fix the compiler errors.

### DIFF
--- a/game/PsyDoom/ParserTokenizer.h
+++ b/game/PsyDoom/ParserTokenizer.h
@@ -3,6 +3,7 @@
 #include "Macros.h"
 
 #include <functional>
+#include <cstdint>
 
 BEGIN_NAMESPACE(ParserTokenizer)
 


### PR DESCRIPTION
Fixes the errors that happen when trying to compile.

<pre>In file included from <b>/src/game/PsyDoom/ParserTokenizer.cpp:5</b>:
<b>/src/game/PsyDoom/ParserTokenizer.h:10:35:</b> <font color="#CD0000"><b>error: </b></font>‘<b>int32_t</b>’ does not name a type
   10 | typedef std::function&lt;void (const <font color="#CD0000"><b>int32_t</b></font> lineIdx)&gt; VisitLineFunc;
</pre>